### PR TITLE
[BE / feat, refactor] Admin, User 도메인 분리 및 그에 따른 변경

### DIFF
--- a/src/main/java/com/hallym/rehab/domain/admin/entity/Admin.java
+++ b/src/main/java/com/hallym/rehab/domain/admin/entity/Admin.java
@@ -1,0 +1,62 @@
+package com.hallym.rehab.domain.admin.entity;
+
+import com.hallym.rehab.domain.user.entity.MemberRole;
+import com.hallym.rehab.global.baseEntity.BaseTimeEntity;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Entity
+public class Admin extends BaseTimeEntity {
+
+    @Id
+    @Column(nullable = false, unique = true)
+    private String mid;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String password;
+
+    private int age;
+
+    private String sex;
+
+    private String phone;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private Set<MemberRole> roleSet = new HashSet<>(); //권한 정보
+
+//    @Builder.Default
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+//    private Set<Video_Member> video_member = new HashSet<>();
+
+    @ColumnDefault("false")
+    private boolean is_deleted;
+
+    public void addRole(MemberRole memberRole){
+        this.roleSet.add(memberRole);
+    }
+
+    public void changePassword(String password) {
+        this.password = password;
+    }
+
+    public void addUser(String mid, String password, String name, String phone, Set<MemberRole> roleSet) {
+        this.mid = mid;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.roleSet = roleSet;
+    }
+}

--- a/src/main/java/com/hallym/rehab/domain/admin/repository/AdminRepository.java
+++ b/src/main/java/com/hallym/rehab/domain/admin/repository/AdminRepository.java
@@ -1,0 +1,18 @@
+package com.hallym.rehab.domain.admin.repository;
+
+import com.hallym.rehab.domain.admin.entity.Admin;
+import com.hallym.rehab.domain.user.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import javax.transaction.Transactional;
+
+public interface AdminRepository extends JpaRepository<Admin, String> {
+
+    @Modifying
+    @Transactional
+    @Query("update Member m set m.password =:password where m.mid =:mid")
+    void updatePassword(@Param("mid") String mid, @Param("password") String password);
+}

--- a/src/main/java/com/hallym/rehab/domain/room/domain/Audio.java
+++ b/src/main/java/com/hallym/rehab/domain/room/domain/Audio.java
@@ -23,6 +23,8 @@ public class Audio {
     @OneToOne
     private Room room;
 
+    private String summary; // 인공지능이 만들어 낸 음성대화 요약본
+
     @Column(name = "adminAudioURL")
     private String adminAudioURL; // 동영상 URL로 접근할 URL
 

--- a/src/main/java/com/hallym/rehab/domain/room/domain/Room.java
+++ b/src/main/java/com/hallym/rehab/domain/room/domain/Room.java
@@ -1,5 +1,6 @@
 package com.hallym.rehab.domain.room.domain;
 
+import com.hallym.rehab.domain.admin.entity.Admin;
 import com.hallym.rehab.domain.room.dto.RoomResponseDTO;
 import com.hallym.rehab.domain.user.entity.Member;
 import com.hallym.rehab.global.baseEntity.BaseTimeEntity;
@@ -27,7 +28,7 @@ public class Room extends BaseTimeEntity {
 
     @OneToOne
     @JoinColumn(name = "admin_id", referencedColumnName = "mid")
-    private Member admin;
+    private Admin admin;
 
     @OneToOne
     @JoinColumn(name = "user_id", referencedColumnName = "mid")

--- a/src/main/java/com/hallym/rehab/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/room/service/RoomServiceImpl.java
@@ -1,5 +1,7 @@
 package com.hallym.rehab.domain.room.service;
 
+import com.hallym.rehab.domain.admin.entity.Admin;
+import com.hallym.rehab.domain.admin.repository.AdminRepository;
 import com.hallym.rehab.domain.room.domain.Room;
 import com.hallym.rehab.domain.room.dto.RoomResponseDTO;
 import com.hallym.rehab.domain.room.repository.RoomRepository;
@@ -16,15 +18,20 @@ import java.util.UUID;
 @Service
 public class RoomServiceImpl implements RoomService{
     private final RoomRepository roomRepository;
+    private final AdminRepository adminRepository;
     private final MemberRepository memberRepository;
+
 
     @Override
     public String registerRoom(String admin_id, String user_id) {
         Optional<Room> byAdminAndUser = roomRepository.findByAdminAndUser(admin_id, user_id);
         if (byAdminAndUser.isPresent()) return "already exist room";
 
-        Member admin = memberRepository.findByUserId(admin_id);
-        Member user = memberRepository.findByUserId(user_id);
+        Admin admin = adminRepository.findById(admin_id)
+                .orElseThrow(() -> new RuntimeException("해당 아이디는 없는 관리자입니다."));
+        Member user = memberRepository.findById(user_id)
+                .orElseThrow(() -> new RuntimeException("해당 아이디는 없는 사용자입니다."));
+
         roomRepository.save(Room.builder()
                                 .admin(admin)
                                 .user(user)

--- a/src/main/java/com/hallym/rehab/domain/user/entity/Member.java
+++ b/src/main/java/com/hallym/rehab/domain/user/entity/Member.java
@@ -32,12 +32,20 @@ public class Member extends BaseTimeEntity {
 
     private String phone;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Builder.Default
+    private Set<MemberRole> roleSet = new HashSet<>(); //권한 정보
+
 //    @Builder.Default
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 //    private Set<Video_Member> video_member = new HashSet<>();
 
     @ColumnDefault("false")
     private boolean is_deleted;
+
+    public void addRole(MemberRole memberRole){
+        this.roleSet.add(memberRole);
+    }
 
     public void changePassword(String password) {
         this.password = password;
@@ -48,5 +56,6 @@ public class Member extends BaseTimeEntity {
         this.password = password;
         this.name = name;
         this.phone = phone;
+        this.roleSet = roleSet;
     }
 }

--- a/src/main/java/com/hallym/rehab/domain/user/entity/Member.java
+++ b/src/main/java/com/hallym/rehab/domain/user/entity/Member.java
@@ -32,20 +32,12 @@ public class Member extends BaseTimeEntity {
 
     private String phone;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @Builder.Default
-    private Set<MemberRole> roleSet = new HashSet<>(); //권한 정보
-
 //    @Builder.Default
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
 //    private Set<Video_Member> video_member = new HashSet<>();
 
     @ColumnDefault("false")
     private boolean is_deleted;
-
-    public void addRole(MemberRole memberRole){
-        this.roleSet.add(memberRole);
-    }
 
     public void changePassword(String password) {
         this.password = password;
@@ -56,6 +48,5 @@ public class Member extends BaseTimeEntity {
         this.password = password;
         this.name = name;
         this.phone = phone;
-        this.roleSet = roleSet;
     }
 }

--- a/src/main/java/com/hallym/rehab/domain/user/repository/MemberRepository.java
+++ b/src/main/java/com/hallym/rehab/domain/user/repository/MemberRepository.java
@@ -10,9 +10,6 @@ import javax.transaction.Transactional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
-    @Query("SELECT m FROM Member m WHERE m.mid = :mid") //ID에 해당하는 사용자 정보 반환
-    Member findByUserId(@Param("mid") String mid);
-
     @Modifying
     @Transactional
     @Query("update Member m set m.password =:password where m.mid =:mid")

--- a/src/main/java/com/hallym/rehab/domain/user/service/APIUserServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/user/service/APIUserServiceImpl.java
@@ -11,9 +11,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.log4j.Log4j2;
 
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -27,7 +29,8 @@ public class APIUserServiceImpl implements APIUserService{
     private final PasswordEncoder passwordEncoder;
 
     public String getRoleSetByMid(String mid) {
-        Member member = memberRepository.findByUserId(mid);
+        Member member = memberRepository.findById(mid)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 아이디는 없는 사용자입니다."));
         String role = String.join(",", member.getRoleSet().stream().map(MemberRole::getValue).collect(Collectors.toList()));
 
         log.info("해당 유저는 " + role + " 권한을 가지고 있습니다.");
@@ -40,7 +43,8 @@ public class APIUserServiceImpl implements APIUserService{
     }
 
     public void changePassword(String mid, PasswordChangeDTO passwordChangeDTO) throws IncorrectPasswordException {
-        Member member = memberRepository.findByUserId(mid);
+        Member member = memberRepository.findById(mid)
+                .orElseThrow(() -> new RuntimeException("해당 아이디는 없는 사용자입니다."));
         if (!passwordEncoder.matches(passwordChangeDTO.getCurrentPassword(), member.getPassword())) {
             throw new IncorrectPasswordException();
         }

--- a/src/test/java/com/hallym/rehab/domain/room/repository/RoomRepositoryTest.java
+++ b/src/test/java/com/hallym/rehab/domain/room/repository/RoomRepositoryTest.java
@@ -1,5 +1,7 @@
 package com.hallym.rehab.domain.room.repository;
 
+import com.hallym.rehab.domain.admin.entity.Admin;
+import com.hallym.rehab.domain.admin.repository.AdminRepository;
 import com.hallym.rehab.domain.room.domain.Room;
 import com.hallym.rehab.domain.room.dto.RoomResponseDTO;
 import com.hallym.rehab.domain.user.entity.Member;
@@ -28,16 +30,18 @@ class RoomRepositoryTest {
     @Autowired
     RoomRepository roomRepository;
     @Autowired
+    AdminRepository adminRepository;
+    @Autowired
     MemberRepository memberRepository;
 
-    Member admin;
-    Member admin2;
+    Admin admin;
+    Admin admin2;
     Member user;
     Member user2;
 
     @BeforeEach
     void setUp() {
-        admin = Member.builder()
+        admin = Admin.builder()
                 .mid("ldh")
                 .name("이동헌")
                 .password("1111")
@@ -47,7 +51,7 @@ class RoomRepositoryTest {
                 .roleSet(Collections.singleton(MemberRole.ADMIN))
                 .build();
 
-        admin2 = Member.builder()
+        admin2 = Admin.builder()
                 .mid("ldh2")
                 .name("이동헌2")
                 .password("1111")
@@ -77,10 +81,11 @@ class RoomRepositoryTest {
                 .roleSet(Collections.singleton(MemberRole.USER))
                 .build();
 
-        memberRepository.save(admin);
-        memberRepository.save(admin2);
+        adminRepository.save(admin);
+        adminRepository.save(admin2);
         memberRepository.save(user);
         memberRepository.save(user2);
+        adminRepository.flush();
         memberRepository.flush();
     }
 

--- a/src/test/java/com/hallym/rehab/domain/room/service/AudioServiceImplTest.java
+++ b/src/test/java/com/hallym/rehab/domain/room/service/AudioServiceImplTest.java
@@ -1,8 +1,9 @@
 package com.hallym.rehab.domain.room.service;
 
+import com.hallym.rehab.domain.admin.entity.Admin;
+import com.hallym.rehab.domain.admin.repository.AdminRepository;
 import com.hallym.rehab.domain.room.domain.Room;
 import com.hallym.rehab.domain.room.dto.AudioRequestDTO;
-import com.hallym.rehab.domain.room.repository.AudioRepository;
 import com.hallym.rehab.domain.room.repository.RoomRepository;
 import com.hallym.rehab.domain.user.entity.Member;
 import com.hallym.rehab.domain.user.entity.MemberRole;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
@@ -34,18 +34,19 @@ class AudioServiceImplTest {
     @Autowired
     AudioService audioService;
     @Autowired
-    AudioRepository audioRepository;
+    RoomRepository roomRepository;
+    @Autowired
+    AdminRepository adminRepository;
     @Autowired
     MemberRepository memberRepository;
-    @Autowired
-    RoomRepository roomRepository;
 
-    Member admin;
+
+    Admin admin;
     Member user;
 
     @BeforeEach
     void setUp() {
-        admin = Member.builder()
+        admin = Admin.builder()
                 .mid("ldh")
                 .name("이동헌")
                 .password("1111")
@@ -65,7 +66,7 @@ class AudioServiceImplTest {
                 .roleSet(Collections.singleton(MemberRole.USER))
                 .build();
 
-        memberRepository.save(admin);
+        adminRepository.save(admin);
         memberRepository.save(user);
         memberRepository.flush();
 
@@ -87,8 +88,8 @@ class AudioServiceImplTest {
                 mp4Bytes           // 바이트 배열로 읽은 MP4 파일 데이터
         );
 
-        Optional<Room> byAdminAndUser = roomRepository.findByAdminAndUser(admin.getMid(), user.getMid());
-        Room room = byAdminAndUser.get();
+        Room room = roomRepository.findByAdminAndUser(admin.getMid(), user.getMid())
+                .orElseThrow(() -> new RuntimeException("유저와 관리자에 의해 매칭된 방이 없습니다."));
 
         AudioRequestDTO user = AudioRequestDTO.builder()
                 .audioFile(audioFile)

--- a/src/test/java/com/hallym/rehab/domain/room/service/RoomServiceTest.java
+++ b/src/test/java/com/hallym/rehab/domain/room/service/RoomServiceTest.java
@@ -1,5 +1,7 @@
 package com.hallym.rehab.domain.room.service;
 
+import com.hallym.rehab.domain.admin.entity.Admin;
+import com.hallym.rehab.domain.admin.repository.AdminRepository;
 import com.hallym.rehab.domain.room.domain.Room;
 import com.hallym.rehab.domain.room.dto.RoomResponseDTO;
 import com.hallym.rehab.domain.room.repository.RoomRepository;
@@ -28,18 +30,20 @@ class RoomServiceTest {
     @Autowired
     RoomService roomService;
     @Autowired
+    AdminRepository adminRepository;
+    @Autowired
     MemberRepository memberRepository;
     @Autowired
     RoomRepository roomRepository;
 
-    Member admin;
+    Admin admin;
     Member user;
 
 
     @BeforeEach
     @DisplayName("유저 생성")
     void setUp() {
-        admin = Member.builder()
+        admin = Admin.builder()
                 .mid("ldh")
                 .name("이동헌")
                 .password("1111")
@@ -59,17 +63,10 @@ class RoomServiceTest {
                 .roleSet(Collections.singleton(MemberRole.USER))
                 .build();
 
-        memberRepository.save(admin);
+        adminRepository.save(admin);
         memberRepository.save(user);
         memberRepository.flush();
     }
-
-//    @AfterEach
-//    void tearDown() {
-//        memberRepository.delete(admin);
-//        memberRepository.delete(user);
-//        memberRepository.flush();
-//    }
 
     @Test
     @DisplayName("룸 생성 테스트")
@@ -121,11 +118,10 @@ class RoomServiceTest {
     void getRoomListByAdmin() {
         //given
         roomService.registerRoom(admin.getMid(), user.getMid());
-        roomService.registerRoom(admin.getMid(), user.getMid()+"fake");
         //when
         List<RoomResponseDTO> roomListByAdmin = roomService.getRoomListByAdmin(admin.getMid());
         //then
-        assertThat(roomListByAdmin.size()).isEqualTo(2);
+        assertThat(roomListByAdmin.size()).isEqualTo(1);
     }
 
     @Test
@@ -133,11 +129,10 @@ class RoomServiceTest {
     void getRoomListByUser() {
         //given
         roomService.registerRoom(admin.getMid(), user.getMid());
-        roomService.registerRoom(admin.getMid()+"fake", user.getMid());
         //when
         List<RoomResponseDTO> roomListByUser = roomService.getRoomListByUser(user.getMid());
         //then
-        assertThat(roomListByUser.size()).isEqualTo(2);
+        assertThat(roomListByUser.size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## ☑️ Describe your changes
- 도메인 분리에 따른 Room 서비스 로직 변경과 그에 따른 테스트 코드를 변경 하였습니다.
- Admin 도메인은 테스트 하기 위해 임시로 entity와 repository만 만들어 두었습니다.
- User 도메인의 Role 컬럼을 지우려고 하였으나 Security와 연관되어있어서 일단 냅두었습니다. 나중에 시큐리티 설정 시 바꾸시면 될 것 같습니다.

## 📷 Screenshot
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/16c2f511-fd7e-4d1f-867f-8d7ad7fa691a)

## 🔗 Issue number and link
- #5 