### PR TITLE
[BE / feat] Google IMAP 활성화와 JavaMailSender를 이용하여 사용자 이메일 전송 기능을 구현한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ keystore.p12
 myCertificate.crt
 application-local.yml
 application-secret.yml
+application-email.yml

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,12 @@ dependencies {
 			"javax.annotation:javax.annotation-api",
 
 			"com.querydsl:querydsl-apt:${queryDslVersion}:jpa")
+
+
+	//smtp 구현을 위한 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.11'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hallym/rehab/domain/email/controller/EmailController.java
+++ b/src/main/java/com/hallym/rehab/domain/email/controller/EmailController.java
@@ -1,0 +1,26 @@
+package com.hallym.rehab.domain.email.controller;
+
+import com.hallym.rehab.domain.email.service.EmailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/email")
+public class EmailController {
+
+    private final EmailService emailService;
+
+    @PostMapping("/send")
+    public String sendMail(@RequestParam(value = "file", required = false) MultipartFile[] file, String to, String[] cc, String subject, String body) {
+
+        return emailService.sendMail(file, to, cc, subject, body);
+    }
+
+}

--- a/src/main/java/com/hallym/rehab/domain/email/service/EmailService.java
+++ b/src/main/java/com/hallym/rehab/domain/email/service/EmailService.java
@@ -1,0 +1,7 @@
+package com.hallym.rehab.domain.email.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface EmailService  {
+    String sendMail(MultipartFile[] file, String to, String[] cc, String subject, String body);
+}

--- a/src/main/java/com/hallym/rehab/domain/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/email/service/EmailServiceImpl.java
@@ -1,0 +1,59 @@
+package com.hallym.rehab.domain.email.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.mail.internet.MimeMessage;
+import javax.transaction.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailServiceImpl implements EmailService{
+
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    private final JavaMailSender javaMailSender;
+
+    @Override
+    public String sendMail(MultipartFile[] file, String to, String[] cc, String subject, String body) {
+        try {
+            MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true);
+
+            mimeMessageHelper.setFrom(fromEmail);
+            mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setCc(cc);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(body);
+
+            for (MultipartFile multipartFile : file) {
+                mimeMessageHelper.addAttachment(
+                        multipartFile.getOriginalFilename(),
+                        new ByteArrayResource(multipartFile.getBytes()));
+            }
+
+            log.info("Mail---------" + mimeMessage);
+            javaMailSender.send(mimeMessage);
+
+
+            return "mail send";
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}

--- a/src/main/java/com/hallym/rehab/domain/email/service/EmailServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/email/service/EmailServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.mail.internet.MimeMessage;
 import javax.transaction.Transactional;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -40,7 +41,7 @@ public class EmailServiceImpl implements EmailService{
 
             for (MultipartFile multipartFile : file) {
                 mimeMessageHelper.addAttachment(
-                        multipartFile.getOriginalFilename(),
+                        Objects.requireNonNull(multipartFile.getOriginalFilename()), //Null Safety를 위한 wrapping
                         new ByteArrayResource(multipartFile.getBytes()));
             }
 

--- a/src/main/java/com/hallym/rehab/global/config/EmailConfig.java
+++ b/src/main/java/com/hallym/rehab/global/config/EmailConfig.java
@@ -1,0 +1,78 @@
+package com.hallym.rehab.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@PropertySource("classpath:application-email.yml")
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.protocol}")
+    private String protocol;
+
+    @Value("${spring.mail.default-encoding}")
+    private String defaultEncoding;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.require}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connection-timeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.write-timeout}")
+    private int writeTimeout;
+
+    @Bean //JavaMailSender 객체를 생성하고 Spring IoC 컨테이너에 등록
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl(); //JavaMailSenderImpl 객체 생성
+
+        javaMailSender.setProtocol(protocol);
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setDefaultEncoding(defaultEncoding);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connection-timeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.write-timeout", writeTimeout);
+
+        return properties;
+    }
+}


### PR DESCRIPTION
## ☑️ Describe your changes
- 이메일 인증 기능 구현을 위한 spring-boot-starter-mail 의존성 추가하였습니다.
- EmailService 인터페이스와 구현체인 EmailServiceImpl 클래스를 정의하여 첨부파일을 포함하는 email 메세지를 모델링을 합니다. 
-  JavaMailSender 객체를 Spring IoC 컨테이너에서 사용할 수 있기 위해 Bean으로 등록합니다.

## 📷 Screenshot
- POSTMAN
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/80760160/1a6c11d2-620b-461f-9100-d2693e3d1805)

- 이메일 수신 화면
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/80760160/dfb5f358-2366-408e-8d2d-521e2d7ad80b)

## 🔗 Issue number and link
- closed #10 