### PR TITLE
[BE / refactor] Video 검색기능 로직 수정

### DIFF
--- a/src/test/java/com/hallym/rehab/domain/reservation/service/ReservationServiceImplTest.java
+++ b/src/test/java/com/hallym/rehab/domain/reservation/service/ReservationServiceImplTest.java
@@ -14,6 +14,7 @@ import com.hallym.rehab.domain.user.repository.MemberRepository;
 import com.hallym.rehab.global.pageDTO.PageRequestDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -144,5 +145,22 @@ class ReservationServiceImplTest {
         assertThat(result2).isEqualTo("success");
 
         assertThat(timeRepository.findByAdmin(admin.getMid()).size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("create Dummy")
+    @Rollback(value = false)
+    void createDummy() {
+        for (int i = 0; i < 120; i++) {
+            ReservationRequestDTO reservationRequestDTO = ReservationRequestDTO.builder()
+                    .admin_id(admin.getMid())
+                    .user_id(user.getMid())
+                    .content("개발하다가 마음이 아파졌어요.."+i)
+                    .date(LocalDate.of(2023, 9, 20))
+                    .index(i)
+                    .build();
+
+            reservationService.createReservation(reservationRequestDTO);
+        }
     }
 }

--- a/src/test/java/com/hallym/rehab/domain/video/repository/VideoRepositoryTest.java
+++ b/src/test/java/com/hallym/rehab/domain/video/repository/VideoRepositoryTest.java
@@ -73,7 +73,7 @@ class VideoRepositoryTest {
     @Rollback(value = false)
     void videoSearch() {
         // insert dummy video data
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 150; i++) {
             Video video = Video.builder()
                     .admin(admin)
                     .title("동작 제목" + i)


### PR DESCRIPTION
## ☑️ Describe your changes
- queryFactory의 fetchResults가 deprecated 됬다하여 fetch로 바꿨었는데 이렇게하면 List<DTO> 즉 컨텐츠가 바로 반환되어 totalCount 값을 가져 올 수 없었습니다. 그래서 페이징에서 보이는 totalcount가 현재 가져온 데이터로만 표시되어 페이징을 할수 없게되어 fetch()로 다시 변환하였습니다. 
- 위와같이 변환하지 않고 사용하려면 fetch + count 쿼리를 2번 날려야 하므로 fetchResults를 사용하는 것으로 변경 하였습니다.
- 추가적으로 페이징 테스트를 위해 video, reservation 더미를 추가하는 테스트 코드를 추가하였습니다.

## 📷 Screenshot
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/b1f3074d-866b-48f2-8c83-1856c14c542f)


## 🔗 Issue number and link
- #13 