### PR TITLE
[BE / feat] 환자의 수행도 비율 반환

### DIFF
--- a/src/main/java/com/hallym/rehab/domain/chart/dto/ChartResponseDTO.java
+++ b/src/main/java/com/hallym/rehab/domain/chart/dto/ChartResponseDTO.java
@@ -30,6 +30,8 @@ public class ChartResponseDTO {
 
     private String therapist_name; // 담당재활치료사
 
+    private double metrics_rate;
+
     private LocalDate regDate;
 
     private List<RecordDTO> medicalRecords;

--- a/src/main/java/com/hallym/rehab/domain/chart/service/ChartServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/chart/service/ChartServiceImpl.java
@@ -224,6 +224,12 @@ public class ChartServiceImpl implements ChartService {
         return chart;
     }
 
+    /**
+     * patient_id를 받아 Metrics들을 찾고 특정 한도를 넘는 것의 비율을 반환
+     *
+     * @param patient_id
+     * @return rate of over70
+     */
     private double getRateMetricsByPatientId(String patient_id) {
         List<VideoMetrics> metricsList = videoMetricsRepository.findMetricsByPatientId(patient_id);
 

--- a/src/main/java/com/hallym/rehab/domain/video/repository/VideoMetricsRepository.java
+++ b/src/main/java/com/hallym/rehab/domain/video/repository/VideoMetricsRepository.java
@@ -2,6 +2,7 @@ package com.hallym.rehab.domain.video.repository;
 
 import com.hallym.rehab.domain.program.entity.ProgramDetail;
 import com.hallym.rehab.domain.video.entity.VideoMetrics;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,5 +12,8 @@ import java.util.Optional;
 public interface VideoMetricsRepository extends JpaRepository<VideoMetrics, Long> {
 
     @Query("SELECT vm FROM VideoMetrics vm WHERE vm.programDetail = :ProgramDetail")
-    Optional<VideoMetrics> findByProgramDetail(@Param("ProgramDetail")ProgramDetail programDetail);
+    Optional<VideoMetrics> findByProgramDetail(@Param("ProgramDetail") ProgramDetail programDetail);
+
+    @Query("SELECT vm FROM VideoMetrics vm WHERE vm.patient.mid = :patient_id")
+    List<VideoMetrics> findMetricsByPatientId(@Param("patient_id") String patient_id);
 }


### PR DESCRIPTION
## ☑️ Describe your changes
- 환자 차트 DTO에 환자의 수행도 비율 추가

## 📷 Screenshot
- 환자 아이디를 넘기면 비율을 반환해주는 함수를 ChartServiceImpl 클래스에 추가 하였습니다.
- 해당하는 환자의 Metrics가 없다면 0을 반환합니다.
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/aa6d76bb-3556-4629-bc87-ba8b90352540)
![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/d875a5f0-4876-4b14-842e-3f9b857ae52b)

## 🔗 Issue number and link
- #33 