### PR TITLE
[BE / feat] email 인증기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,10 +82,6 @@ dependencies {
 	implementation 'net.coobird:thumbnailator:0.4.17'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
-}
-
 sourceSets {
 	main {
 		java {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ dependencies {
 	/* 동적 쿼리를 사용한 페이징과 검색 처리를 위해 querydsl 의존성 추가*/
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 
+	/* 이메일 인증을 위한 redis 및 redis client (lettuce) */
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.3.2.RELEASE'
+
+
 	annotationProcessor(
 
 			"javax.persistence:javax.persistence-api",

--- a/src/main/java/com/hallym/rehab/domain/room/service/AudioServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/room/service/AudioServiceImpl.java
@@ -55,7 +55,7 @@ public class AudioServiceImpl implements AudioService {
         if (audio.getUserAudioURL() != null && audio.getAdminAudioURL() != null) {
             Long ano = audio.getAno();
             RestTemplate restTemplate = new RestTemplate();
-            return restTemplate.getForObject("http://210.115.229.219:8000/getSummary?ano=" + ano.toString(),
+            return restTemplate.getForObject("http://210.115.229.219:8080/getSummary?ano=" + ano.toString(),
                     String.class);
         }
 

--- a/src/main/java/com/hallym/rehab/domain/user/controller/SmtpController.java
+++ b/src/main/java/com/hallym/rehab/domain/user/controller/SmtpController.java
@@ -1,0 +1,28 @@
+package com.hallym.rehab.domain.user.controller;
+
+import com.hallym.rehab.domain.user.dto.EmailDTO;
+import com.hallym.rehab.domain.user.service.SmtpGmailSenderImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/email")
+@RequiredArgsConstructor
+public class SmtpController {
+    private final SmtpGmailSenderImpl senderService;
+
+    @GetMapping("/send-code/{email}")
+    public ResponseEntity<String> sendEmail(@PathVariable String email) {
+        senderService.sendEmail(email);
+        return ResponseEntity.ok("Email sent");
+    }
+
+    @PostMapping(value = "/verify-code/{email}", consumes = "application/json")
+    public ResponseEntity<String> sendEmailAndCode(@PathVariable String email, @RequestBody EmailDTO dto) {
+        if (senderService.verifyAuthCode(email, dto.getAuthCode())) {
+            return ResponseEntity.ok("Email verified");
+        }
+        return ResponseEntity.badRequest().body("Email verification failed");
+    }
+}

--- a/src/main/java/com/hallym/rehab/domain/user/dto/EmailDTO.java
+++ b/src/main/java/com/hallym/rehab/domain/user/dto/EmailDTO.java
@@ -1,0 +1,8 @@
+package com.hallym.rehab.domain.user.dto;
+
+import lombok.Data;
+
+@Data
+public class EmailDTO {
+    private String authCode;
+}

--- a/src/main/java/com/hallym/rehab/domain/user/service/SmtpGmailSenderImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/user/service/SmtpGmailSenderImpl.java
@@ -1,0 +1,60 @@
+package com.hallym.rehab.domain.user.service;
+
+import com.hallym.rehab.global.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class SmtpGmailSenderImpl implements SmtpGmailSenderService{
+    private final JavaMailSender emailSender;
+    private final RedisUtil redisUtil;
+    @Value("${spring.mail.username}")
+    private String from;
+
+    @Override
+    public void sendEmail(String toEmail) {
+        if(redisUtil.existData(toEmail)) {
+            redisUtil.deleteData(toEmail);
+        }
+
+        String cipher = createCipher();
+        redisUtil.setDataExpire(toEmail, cipher, 60 * 5L);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(from);
+        message.setTo(toEmail);
+        message.setSubject("이메일 인증번호를 알려드립니다.");
+        message.setText("5분안에 입력해야 합니다. \n" + "인증번호 : " + cipher);
+
+        emailSender.send(message);
+    }
+
+    @Override
+    public Boolean verifyAuthCode(String email, String authCode) {
+        String authCodeFoundByEmail = redisUtil.getData(email);
+        if (authCodeFoundByEmail == null) {
+            return false;
+        }
+        return authCodeFoundByEmail.equals(authCode);
+    }
+
+    @Override
+    public String createCipher() {
+        int leftLimit = 48; // number '0'
+        int rightLimit = 122; // alphabet 'z'ß
+        int targetStringLength = 6;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+                .filter(i -> (i <=57 || i >=65) && (i <= 90 || i>= 97))
+                .limit(targetStringLength)
+                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                .toString();
+    }
+}

--- a/src/main/java/com/hallym/rehab/domain/user/service/SmtpGmailSenderService.java
+++ b/src/main/java/com/hallym/rehab/domain/user/service/SmtpGmailSenderService.java
@@ -1,0 +1,7 @@
+package com.hallym.rehab.domain.user.service;
+
+public interface SmtpGmailSenderService {
+    void sendEmail(String toEmail);
+    Boolean verifyAuthCode(String email, String authCode);
+    String createCipher();
+}

--- a/src/main/java/com/hallym/rehab/global/config/RedisConfig.java
+++ b/src/main/java/com/hallym/rehab/global/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.hallym.rehab.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(redisHost);
+        redisConfig.setPort(redisPort);
+        redisConfig.setPassword(redisPassword);
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory((redisConnectionFactory()));
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/hallym/rehab/global/util/RedisUtil.java
+++ b/src/main/java/com/hallym/rehab/global/util/RedisUtil.java
@@ -1,0 +1,34 @@
+package com.hallym.rehab.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+    private final StringRedisTemplate template;
+
+    public String getData(String key) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public boolean existData(String key) {
+        return Boolean.TRUE.equals(template.hasKey(key));
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        ValueOperations<String, String> valueOperations = template.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        template.delete(key);
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: secret
+    active: local, email


### PR DESCRIPTION
## ☑️ Describe your changes
- redis cloud와 redis client (rettuce) 를 이용하여 이메일 인증서비스 구현

## 📷 Screenshot
get으로 사용자 이메일을 담아서 요청하면 랜덤 문자열 생성 후 smtp 프로토콜을 활용하여 해당 메일로 보냄

<img width="320" alt="image" src="https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/4ccb6a80-b097-4483-b4f9-224abc13a883">

받은 문자열을 post 요청에 body에 담아서 인증

![image](https://github.com/sync-without-async/Rehab-BackEnd/assets/52206904/01525e96-796c-4f56-bc04-1793ee42c4d5)